### PR TITLE
Add API for registering event handlers

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -151,9 +151,30 @@ function ItemRack.OnLoad(self)
 end
 
 ItemRack.EventHandlers = {}
+ItemRack.ExternalEventHandlers = {}
 
 function ItemRack.OnEvent(self,event,...)
 	ItemRack.EventHandlers[event](self,event,...)
+end
+
+--- Allows third-party addons to listen to ItemRack events, like saving and deleting a set.
+function ItemRack.RegisterExternalEventListener(self,event,handler)
+	local handlers = ItemRack.ExternalEventHandlers[event]
+	if handlers == nil then
+		handlers = {}
+		ItemRack.ExternalEventHandlers[event] = handlers
+	end
+	
+	table.insert(handlers, handler)
+end
+
+function ItemRack.FireItemRackEvent(self,event,...)
+	local handlers = ItemRack.ExternalEventHandlers[event]
+	if handlers ~= nil then
+		for _, handler in pairs(handlers) do
+			handler(event,...)
+		end
+	end
 end
 
 function ItemRack.OnPlayerLogin()

--- a/ItemRackOptions/ItemRackOptions.lua
+++ b/ItemRackOptions/ItemRackOptions.lua
@@ -406,6 +406,7 @@ function ItemRackOpt.SaveSet()
 	-- set.equip[18] = nil
 	ItemRackOpt.ReconcileSetBindings()
 	ItemRackOpt.ValidateSetButtons()
+	ItemRack:FireItemRackEvent("ITEMRACK_SET_SAVED", setname)
 end
 
 function ItemRackOpt.ValidateSetButtons()
@@ -452,10 +453,12 @@ function ItemRackOpt.LoadSet()
 end
 
 function ItemRackOpt.DeleteSet()
-	ItemRackUser.Sets[ItemRackOptSetsName:GetText()] = nil
+	local setname = ItemRackOptSetsName:GetText()
+	ItemRackUser.Sets[setname] = nil
 	ItemRackOpt.PopulateSetList()
 	ItemRack.CleanupEvents()
 	ItemRackOpt.PopulateEventList()
+	ItemRack:FireItemRackEvent("ITEMRACK_SET_DELETED", setname)
 end
 
 function ItemRackOpt.HideSet()


### PR DESCRIPTION
I'm developing an `ItemRack` filter for `AdiBags`, and I'd like to have a way for the filter to update when an `ItemRack` set is changed.  Right now, the only way that I could find to do that is to wait for `ItemRackOptions` to load, and replace the save and delete functions with my own wrapper function.

This PR adds a very general event system to `ItemRack`, and implements two events: `SET_SAVED` and `SET_DELETED`.