### PR TITLE
Fixed a problem with scripts not receiving event parameters

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -3,7 +3,7 @@ ItemRack = {}
 local disable_delayed_swaps = nil -- temporary. change nil to 1 to stop attempting to delay set swaps while casting
 local _
 
-ItemRack.Version = "3.25"
+ItemRack.Version = "3.26"
 
 ItemRackUser = {
 	Sets = {}, -- user's sets

--- a/ItemRack/ItemRackEvents.lua
+++ b/ItemRack/ItemRackEvents.lua
@@ -280,7 +280,8 @@ function ItemRack.ProcessingFrameOnEvent(self,event,...)
 		elseif event=="ZONE_CHANGED_NEW_AREA" and eventType=="Zone" then
 			startZone = 1
 		elseif eventType=="Script" and events[eventName].Trigger==event then
-			RunScript(events[eventName].Script)
+			local method = loadstring(events[eventName].Script)
+			pcall(method, ...)
 		end
 	end
 	if startStance then

--- a/ItemRack/change log.txt
+++ b/ItemRack/change log.txt
@@ -1,3 +1,7 @@
+__ New in 3.26 - By Cactus __
+
+* Added Events parameters to scripts
+
 __ New in 3.08 - By Kharthus __
 
 * Bug fixes for event and queue errors


### PR DESCRIPTION
I was trying to use event parameters in scripts but I wasn't able to receive parameters. Here's a fix to the Script call to enable parameters usage.