### PR TITLE
Update ItemRackEvents.lua

### DIFF
--- a/ItemRack/ItemRackEvents.lua
+++ b/ItemRack/ItemRackEvents.lua
@@ -382,6 +382,14 @@ function ItemRack.CheckForMountedEvents()
 	
 	local isPlayerMounted = IsMounted() and not UnitOnTaxi("player")
 	if isPlayerMounted ~= _lastStateMounted then
+		-- Disable queues if mounted, re-enable them when dismounted
+		-- This allows users to use priority-queues for their non-mount slots and allow ItemRack to equip the correct non-mount gear after a dismount
+		if isPlayerMounted == false then
+			ItemRackUser.EnableQueues="ON"
+		else
+			ItemRackUser.EnableQueues="OFF"
+		end
+		
 		_lastStateMounted = isPlayerMounted
 		ItemRack.ProcessBuffEvent()
 	end


### PR DESCRIPTION
Disable priority queues while mounted, re-enable them on dismount.

ItemRack has a bug with queues in classic where items are sometimes not correctly equipped following a dismount if the user was in combat when dismounting. By disabling the queues while mounted, users can enable priority queues for specific slots they want always equipped after dismounting. Since the queues are disabled while mounted, the mount event set of gear will stay equipped while mounted. After a dismount, queues turning on would equip the non-mount set correctly.

