### PR TITLE
Prevent unequipping sets that are not marked to unequip for buff events

### DIFF
--- a/ItemRack/ItemRackEvents.lua
+++ b/ItemRack/ItemRackEvents.lua
@@ -431,7 +431,7 @@ function ItemRack.ProcessBuffEvent()
 				isSetEquipped = ItemRack.IsSetEquipped(setname)
 				if buff and not isSetEquipped then
 					ItemRack.EquipSet(setname)
-				elseif not buff and isSetEquipped then
+				elseif not buff and isSetEquipped and events[eventName].Unequip then
 					ItemRack.UnequipSet(setname)
 				end
 			end


### PR DESCRIPTION
You could have buff A, buff B, or neither, but not both. One set is associated with buff A, another is associated with buff B. If you had neither buff, the addon would try to unquip both sets and could enter a cycle of toggling between set A and set B. This change resolves that issue by enforcing the absence of the Unequip flag.