### PR TITLE
Fix individual slot queue toggle

### DIFF
--- a/ItemRack/ItemRackQueue.lua
+++ b/ItemRack/ItemRackQueue.lua
@@ -6,8 +6,10 @@ function ItemRack.PeriodicQueueCheck()
 		return
 	end
 	if ItemRackUser.EnableQueues=="ON" then
-		for i in pairs(ItemRackUser.QueuesEnabled) do
-			ItemRack.ProcessAutoQueue(i)
+		for i,v in pairs(ItemRackUser.QueuesEnabled) do
+			if v and v == true then
+				ItemRack.ProcessAutoQueue(i)
+			end
 		end
 	end
 end


### PR DESCRIPTION
The addon currently tries to queue all slots and ignores the checkbox "Auto queue this slot"
This will make it check the table to see if the box was actually ticked before queuing a slot.