### PR TITLE
Added an event to process swaps on Feign Death

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -267,6 +267,17 @@ function ItemRack.OnUnitInventoryChanged(self,event,unit)
 	end
 end
 
+function ItemRack.OnFeignDeath(self,event,unit)
+	if unit=="player" then
+		for i=1,32 do
+			local _, _, _, _, _, _, _, _, _, spell_id = UnitAura("player", i, "HELPFUL|PLAYER|CANCELABLE")
+			if spell_id == 5384 then -- FD
+				ItemRack.ProcessCombatQueue()
+			end
+		end
+	end
+end
+
 function ItemRack.OnLeavingCombatOrDeath()
 	ItemRack.inCombat = InCombatLockdown()
 	if ItemRack.NowCasting then
@@ -355,6 +366,11 @@ function ItemRack.UpdateClassSpecificStuff()
 
 	if class=="SHAMAN" then
 		ItemRack.CanWearOneHandOffHand = 1
+	end
+
+	if class=="HUNTER" then -- Feign Death specific swapping logic.
+		ItemRackFrame:RegisterEvent("UNIT_AURA")
+		ItemRack.EventHandlers.UNIT_AURA = ItemRack.OnFeignDeath
 	end
 end
 


### PR DESCRIPTION
Moving into phase 5 of classic, hunters are beginning to swap trinkets 2-3 times per fight.  Trinket swapping using FD has felt slower in Itemrack than using a spammable macro.  After some testing using a Weakaura which attempts to swap trinkets every frame after FD has been cast, it seems like this is because trinkets can be swapped earlier than the events which Itemrack uses to trigger processing the swap queue.

Using the same Weakaura I figured out that trinkets can be swapped as soon as the UNIT_AURA update corresponding to Feign Death's buff has been fired (assuming FD isn't resisted).  This is my attempt at having itemrack register for and respond to that event for responsive FD trinket swapping.

I'm really not a LUA dev and I'm by no means certain that `ItemRack.ProcessCombatQueue()` was the correct thing to do here, but it seems to be working much more consistently now and swapping around .6-1s after FD is cast.

Please let me know if you would suggest any changes!