### PR TITLE
Add a Except PVE Instance Check to the Buff/Mount Events

### DIFF
--- a/ItemRack/ItemRackEvents.lua
+++ b/ItemRack/ItemRackEvents.lua
@@ -425,6 +425,12 @@ function ItemRack.ProcessBuffEvent()
 					skip = 1
 				end
 			end
+			if events[eventName].NotInPVE then
+				local _,instanceType = IsInInstance()
+				if instanceType=="party" or instanceType=="raid" then
+					skip = 1
+				end
+			end
 			if not skip then
 				if events[eventName].Anymount then
 					buff = IsMounted() and not UnitOnTaxi("player")

--- a/ItemRackOptions/ItemRackOptions.lua
+++ b/ItemRackOptions/ItemRackOptions.lua
@@ -22,6 +22,7 @@ ItemRack.CheckButtonLabels = {
 	["ItemRackOptEventEditBuffAnyMountText"] = "Any mount",
 	["ItemRackOptEventEditBuffUnequipText"] = "Unequip when buff fades",
 	["ItemRackOptEventEditBuffNotInPVPText"] = "Except in PVP instances",
+	["ItemRackOptEventEditBuffNotInPVEText"] = "Except in PVE instances",
 	["ItemRackOptEventEditStanceUnequipText"] = "Unequip on leaving stance",
 	["ItemRackOptEventEditZoneUnequipText"] = "Unequip on leaving zone",
 	["ItemRackOptEventEditStanceNotInPVPText"] = "Except in PVP instances",
@@ -1641,6 +1642,7 @@ function ItemRackOpt.EventEditClearFrame()
 	ItemRackOptEventEditBuffAnyMount:SetChecked(false)
 	ItemRackOptEventEditBuffUnequip:SetChecked(false)
 	ItemRackOptEventEditBuffNotInPVP:SetChecked(false)
+	ItemRackOptEventEditBuffNotInPVE:SetChecked(false)
 	ItemRackOptEventEditStanceName:SetText("")
 	ItemRackOptEventEditStanceUnequip:SetChecked(false)
 	ItemRackOptEventEditStanceNotInPVP:SetChecked(false)
@@ -1667,6 +1669,7 @@ function ItemRackOpt.EventEditPopulateFrame()
 		end
 		ItemRackOptEventEditBuffUnequip:SetChecked(event.Unequip)
 		ItemRackOptEventEditBuffNotInPVP:SetChecked(event.NotInPVP)
+		ItemRackOptEventEditBuffNotInPVE:SetChecked(event.NotInPVE)
 		ItemRackOptEventEditStanceName:SetText(event.Stance or "")
 		ItemRackOptEventEditStanceUnequip:SetChecked(event.Unequip)
 		ItemRackOptEventEditStanceNotInPVP:SetChecked(event.NotInPVP)
@@ -1818,6 +1821,7 @@ function ItemRackOpt.EventEditSave(override)
 		event.Buff = ItemRackOptEventEditBuffName:GetText()
 		event.Unequip = ItemRackOptEventEditBuffUnequip:GetChecked()
 		event.NotInPVP = ItemRackOptEventEditBuffNotInPVP:GetChecked()
+		event.NotInPVE = ItemRackOptEventEditBuffNotInPVE:GetChecked()
 	elseif event.Type=="Stance" then
 		event.Stance = ItemRackOptEventEditStanceName:GetText()
 		if tonumber(event.Stance) then

--- a/ItemRackOptions/ItemRackOptions.xml
+++ b/ItemRackOptions/ItemRackOptions.xml
@@ -2695,12 +2695,20 @@
 									<Anchor point="TOPLEFT" relativeTo="ItemRackOptEventEditBuffAnyMount" relativePoint="BOTTOMLEFT"/>
 								</Anchors>
 							</CheckButton>
-							<CheckButton name="ItemRackOptEventEditBuffUnequip" inherits="ItemRackOptSimpleCheckButton">
+							<CheckButton name="ItemRackOptEventEditBuffNotInPVE" inherits="ItemRackOptSimpleCheckButton">
 								<Size>
 									<AbsDimension x="26" y="26"/>
 								</Size>
 								<Anchors>
 									<Anchor point="TOPLEFT" relativeTo="ItemRackOptEventEditBuffNotInPVP" relativePoint="BOTTOMLEFT"/>
+								</Anchors>
+							</CheckButton>
+							<CheckButton name="ItemRackOptEventEditBuffUnequip" inherits="ItemRackOptSimpleCheckButton">
+								<Size>
+									<AbsDimension x="26" y="26"/>
+								</Size>
+								<Anchors>
+									<Anchor point="TOPLEFT" relativeTo="ItemRackOptEventEditBuffNotInPVE" relativePoint="BOTTOMLEFT"/>
 								</Anchors>
 							</CheckButton>
 						</Frames>


### PR DESCRIPTION
With AQ being an instance where you can mount and enter combat easily you should be able to disable a set from equipping so that you are fully prepared for the fight without carrot/spur boots equipping. 