### PR TITLE
Fix lua error when initializing the addon in combat (E.g by /reload)

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -2,7 +2,7 @@ ItemRack = {}
 
 local _
 
-ItemRack.Version = "3.52"
+ItemRack.Version = "3.53"
 
 ItemRackUser = {
 	Sets = {}, -- user's sets
@@ -175,7 +175,7 @@ function ItemRack.RegisterExternalEventListener(self,event,handler)
 		handlers = {}
 		ItemRack.ExternalEventHandlers[event] = handlers
 	end
-	
+
 	table.insert(handlers, handler)
 end
 
@@ -473,7 +473,11 @@ function ItemRack.InitCore()
 	ItemRack.StartTimer("CooldownUpdate")
 	ItemRack.MoveMinimap()
 	ItemRack.ReflectAlpha()
-	ItemRack.SetSetBindings()
+	if InCombatLockdown() then
+		table.insert(ItemRack.RunAfterCombat, "SetSetBindings")
+	else
+		ItemRack.SetSetBindings()
+	end
 
 	SlashCmdList["ItemRack"] = ItemRack.SlashHandler
 	SLASH_ItemRack1 = "/itemrack"
@@ -842,7 +846,7 @@ end
 -- func = function to run when the delay finishes
 -- delay = time (in seconds) after the timer is started before func is run
 -- rep = nil or 1, whether to repeat the delay once it's reached
--- 
+--
 -- The standard use is to create a timer, and then ItemRack.StartTimer
 -- when you want to run the delayed function.
 --
@@ -1335,7 +1339,7 @@ function ItemRack.EquipItemByID(id,slot)
 			end
 		end
 	end
-end	
+end
 
 --[[ Hooks to capture item use outside the mod ]]
 
@@ -2105,7 +2109,7 @@ function ItemRack.GetQueues()
 		if not (ItemRackUser.CurrentSet and ItemRackUser.Sets[ItemRackUser.CurrentSet]) then
 			return ItemRackUser.Queues
 		end
-		
+
 		local currentSet = ItemRackUser.Sets[ItemRackUser.CurrentSet]
 		if not currentSet.Queues then
 			currentSet.Queues = {}
@@ -2122,7 +2126,7 @@ function ItemRack.GetQueuesEnabled()
 		if not (ItemRackUser.CurrentSet and ItemRackUser.Sets[ItemRackUser.CurrentSet]) then
 			return ItemRackUser.QueuesEnabled
 		end
-		
+
 		local currentSet = ItemRackUser.Sets[ItemRackUser.CurrentSet]
 		if not currentSet.QueuesEnabled then
 			currentSet.QueuesEnabled = {}

--- a/ItemRack/ItemRack.toc
+++ b/ItemRack/ItemRack.toc
@@ -1,4 +1,4 @@
-## Interface: 11305
+## Interface: 11306
 ## Title: ItemRack
 ## Author: Gello - Updated for Classic by Rottenbeer
 ## SavedVariables: ItemRackSettings, ItemRackItems, ItemRackEvents

--- a/ItemRack/ItemRackButtons.lua
+++ b/ItemRack/ItemRackButtons.lua
@@ -16,6 +16,11 @@ ItemRack.LockedButtons = {} -- buttons locked (desaturated)
 ItemRack.NewAnchor = nil
 
 function ItemRack.InitButtons()
+	if InCombatLockdown() then
+		table.insert(ItemRack.RunAfterCombat, "InitButtons")
+		return
+	end
+
 	ItemRackUser.Buttons = ItemRackUser.Buttons or {}
 
 	ItemRack.oldPaperDollItemSlotButton_OnModifiedClick = PaperDollItemSlotButton_OnModifiedClick
@@ -55,7 +60,7 @@ function ItemRack.InitButtons()
 	ItemRackMenuFrame:SetScript("OnMouseUp",ItemRack.MenuFrameOnMouseUp)
 	ItemRackMenuFrame:EnableMouse(true)
 
-	ItemRack.CreateTimer("ReflectClickedUpdate",ItemRack.ReflectClickedUpdate,.2,1)		
+	ItemRack.CreateTimer("ReflectClickedUpdate",ItemRack.ReflectClickedUpdate,.2,1)
 
 	ItemRackFrame:RegisterEvent("UNIT_INVENTORY_CHANGED")
 	ItemRackFrame:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN")

--- a/ItemRackOptions/ItemRackOptions.toc
+++ b/ItemRackOptions/ItemRackOptions.toc
@@ -1,4 +1,4 @@
-## Interface: 11305
+## Interface: 11306
 ## Title: ItemRackOptions
 ## Notes: Load-On-Demand modules for ItemRack
 ## Dependencies: ItemRack, Blizzard_MacroUI


### PR DESCRIPTION
`ItemRack.SetBindings` and `ItemRack.InitButtons` triggers some protected Blizzard functions which can't be ran in combat. This PR fixes that by running these functions only while outside of combat.