### PR TITLE
Fix addon not initializing while in combat

### DIFF
--- a/ItemRack/ItemRack.toc
+++ b/ItemRack/ItemRack.toc
@@ -1,4 +1,4 @@
-## Interface: 11305
+## Interface: 11306
 ## Title: ItemRack
 ## Author: Gello - Updated for Classic by Rottenbeer
 ## SavedVariables: ItemRackSettings, ItemRackItems, ItemRackEvents

--- a/ItemRack/ItemRack.xml
+++ b/ItemRack/ItemRack.xml
@@ -1,9 +1,6 @@
 <Ui>
 	<Frame name="ItemRackFrame" hidden="true">
 		<Scripts>
-			<OnLoad>
-				ItemRack.OnLoad(self)
-			</OnLoad>
 			<OnEvent>
 				ItemRack.OnEvent(self,event,...)
 			</OnEvent>

--- a/ItemRackOptions/ItemRackOptions.toc
+++ b/ItemRackOptions/ItemRackOptions.toc
@@ -1,4 +1,4 @@
-## Interface: 11305
+## Interface: 11306
 ## Title: ItemRackOptions
 ## Notes: Load-On-Demand modules for ItemRack
 ## Dependencies: ItemRack, Blizzard_MacroUI


### PR DESCRIPTION
This PR makes the addon initialize while in combat. Previously it would error out and not load until you reload ui out of combat. (since it calls some secure blizzard functions)
Running the code immediately on login instead of delaying it gives us a grace period where it allows you to run secure code in combat.

You can probably remove the `local loader = CreateFrame("Frame")` part and instead trigger `ItemRack.OnPlayerLogin` manually but this requires some reordering of functions.