### PR TITLE
Update ItemRack for 3.4.1

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -598,7 +598,7 @@ end
 function ItemRack.GetID(bag,slot)
 	local itemLink
 	if slot then
-		itemLink = GetContainerItemLink(bag,slot)
+		itemLink = C_Container.GetContainerItemLink(bag,slot)
 	else
 		itemLink = GetInventoryItemLink("player",bag)
 	end
@@ -656,7 +656,7 @@ function ItemRack.FindItem(id,lock)
 
 	-- search bags
 	for i=4,0,-1 do
-		for j=1,GetContainerNumSlots(i) do
+		for j=1,C_Container.GetContainerNumSlots(i) do
 			if id==getid(i,j) and (not lock or not locklist[i][j]) then
 				if lock then locklist[i][j]=1 end
 				return nil,i,j
@@ -672,7 +672,7 @@ function ItemRack.FindItem(id,lock)
 	end
 	-- search bags for base id matches
 	for i=4,0,-1 do
-		for j=1,GetContainerNumSlots(i) do
+		for j=1,C_Container.GetContainerNumSlots(i) do
 			if sameid(id,getid(i,j)) and (not lock or not locklist[i][j]) then
 				if lock then locklist[i][j]=1 end
 				return nil,i,j
@@ -699,7 +699,7 @@ function ItemRack.FindInBank(id,lock)
 	if ItemRack.BankOpen then -- only proceed if bank is open
 		for _,i in pairs(ItemRack.BankSlots) do -- try to find an exact match at first
 			if ItemRack.ValidBag(i) then
-				for j=1,GetContainerNumSlots(i) do
+				for j=1,C_Container.GetContainerNumSlots(i) do
 					if id==getid(i,j) and (not lock or locklist[i][j]) then
 						if lock then locklist[i][j]=1 end
 						return i,j
@@ -709,7 +709,7 @@ function ItemRack.FindInBank(id,lock)
 		end
 		for _,i in pairs(ItemRack.BankSlots) do -- otherwise resort to a loose baseID match
 			if ItemRack.ValidBag(i) then
-				for j=1,GetContainerNumSlots(i) do
+				for j=1,C_Container.GetContainerNumSlots(i) do
 					if sameid(id,getid(i,j)) and (not lock or not locklist[i][j]) then
 						if lock then locklist[i][j]=1 end
 						return i,j
@@ -755,8 +755,8 @@ end
 function ItemRack.FindSpace()
 	for i=4,0,-1 do
 		if ItemRack.ValidBag(i) then
-			for j=1,GetContainerNumSlots(i) do
-				if not GetContainerItemLink(i,j) and not ItemRack.LockList[i][j] then
+			for j=1,C_Container.GetContainerNumSlots(i) do
+				if not C_Container.GetContainerItemLink(i,j) and not ItemRack.LockList[i][j] then
 					ItemRack.LockList[i][j] = 1
 					return i,j
 				end
@@ -769,8 +769,8 @@ function ItemRack.FindBankSpace()
 	if not ItemRack.BankOpen then return end
 	for _,i in pairs(ItemRack.BankSlots) do
 		if ItemRack.ValidBag(i) then
-			for j=1,GetContainerNumSlots(i) do
-				if not GetContainerItemLink(i,j) and not ItemRack.LockList[i][j] then
+			for j=1,C_Container.GetContainerNumSlots(i) do
+				if not C_Container.GetContainerItemLink(i,j) and not ItemRack.LockList[i][j] then
 					ItemRack.LockList[i][j] = 1
 					return i,j
 				end
@@ -854,7 +854,7 @@ function ItemRack.PopulateKnownItems()
 		end
 	end
 	for i=0,4 do
-		for j=1,GetContainerNumSlots(i) do
+		for j=1,C_Container.GetContainerNumSlots(i) do
 			id = getid(i,j) --grab ItemRack-style ID for every bag item
 			if id~=0 then
 				if IsEquippableItem(ItemRack.GetIRString(id,true)) then --only proceed if this is an equippable item (test against the baseID of the item)
@@ -1007,7 +1007,7 @@ function ItemRack.BuildMenu(id,menuInclude,masqueGroup)
 			end
 		end
 		for i=0,4 do
-			for j=1,GetContainerNumSlots(i) do
+			for j=1,C_Container.GetContainerNumSlots(i) do
 				itemID = ItemRack.GetID(i,j)
 				itemName,itemTexture,equipSlot = ItemRack.GetInfoByID(itemID)
 				if ItemRack.SlotInfo[id][equipSlot] and ItemRack.PlayerCanWear(id,i,j) and (ItemRackSettings.HideTradables=="OFF" or ItemRack.IsSoulbound(i,j)) then
@@ -1019,7 +1019,7 @@ function ItemRack.BuildMenu(id,menuInclude,masqueGroup)
 		end
 		if ItemRack.BankOpen then
 			for _,i in pairs(ItemRack.BankSlots) do
-				for j=1,GetContainerNumSlots(i) do
+				for j=1,C_Container.GetContainerNumSlots(i) do
 					itemID = ItemRack.GetID(i,j)
 					itemName,itemTexture,equipSlot = ItemRack.GetInfoByID(itemID)
 					if ItemRack.SlotInfo[id][equipSlot] and ItemRack.PlayerCanWear(id,i,j) and (ItemRackSettings.HideTradables=="OFF" or ItemRack.IsSoulbound(i,j)) then
@@ -1171,7 +1171,7 @@ function ItemRack.UpdateMenuCooldowns()
 	for i=1,#(ItemRack.Menu) do
 		baseID = tonumber(ItemRack.GetIRString(ItemRack.Menu[i],true)) --get baseID and convert it to number to be able to use it in numerical comparisons below
 		if baseID and baseID>0 and ItemRack.menuOpen<20 then
-			CooldownFrame_Set(_G["ItemRackMenu"..i.."Cooldown"],GetItemCooldown(baseID))
+			CooldownFrame_Set(_G["ItemRackMenu"..i.."Cooldown"],C_Container.GetItemCooldown(baseID))
 		else
 			_G["ItemRackMenu"..i.."Cooldown"]:Hide()
 		end
@@ -1185,7 +1185,7 @@ function ItemRack.WriteMenuCooldowns()
 		for i=1,#(ItemRack.Menu) do
 			baseID = ItemRack.GetIRString(ItemRack.Menu[i],true)
 			if baseID then
-				ItemRack.WriteCooldown(_G["ItemRackMenu"..i.."Time"],GetItemCooldown(baseID))
+				ItemRack.WriteCooldown(_G["ItemRackMenu"..i.."Time"],C_Container.GetItemCooldown(baseID))
 			else
 				_G["ItemRackMenu"..i.."Time"]:SetText("")
 			end
@@ -1251,7 +1251,7 @@ end
 function ItemRack.ChatLinkID(itemID)
 	local inv,bag,slot = ItemRack.FindItem(itemID)
 	if bag then
-		ChatFrame1EditBox:Insert(GetContainerItemLink(bag,slot))
+		ChatFrame1EditBox:Insert(C_Container.GetContainerItemLink(bag,slot))
 	elseif inv then
 		ChatFrame1EditBox:Insert(GetInventoryItemLink("player",inv))
 	else
@@ -1346,7 +1346,7 @@ function ItemRack.EquipItemByID(id,slot)
 				if not isLocked and not IsInventoryItemLocked(slot) then
 					-- neither container item nor inventory item locked, perform swap
 					local _,_,equipSlot = ItemRack.GetInfoByID(id)
-					if equipSlot~="INVTYPE_2HWEAPON" or (ItemRack.HasTitansGrip and not ItemRack.NoTitansGrip[select(7,GetItemInfo(GetContainerItemLink(b,s))) or ""]) or not GetInventoryItemLink("player",17) then
+					if equipSlot~="INVTYPE_2HWEAPON" or (ItemRack.HasTitansGrip and not ItemRack.NoTitansGrip[select(7,GetItemInfo(C_Container.GetContainerItemLink(b,s))) or ""]) or not GetInventoryItemLink("player",17) then
 						PickupContainerItem(b,s)
 						PickupInventoryItem(slot)
 					else
@@ -1512,7 +1512,7 @@ function ItemRack.IDTooltip(self,itemID) --itemID is an ItemRack-style ID
 	else --cannot find the item in player's inventory or worn equipment!
 		bag,slot = ItemRack.FindInBank(itemID) --try to find the item in the player's bank IF they currently have the bank frame open
 		if bag then -- item found in player's bank
-			itemID = GetContainerItemLink(bag,slot) -- grab the itemLink from the found item in the player's bank
+			itemID = C_Container.GetContainerItemLink(bag,slot) -- grab the itemLink from the found item in the player's bank
 		else -- item is completely missing (no such strict OR baseID found anywhere): it's not in inventory, bank or worn items
 			itemID = ItemRack.IRStringToItemString(ItemRack.UpdateIRString(itemID)) -- ensure the stored ID is brought up to date, then generate a regular ItemString from it which can be used to display the required tooltip
 		end
@@ -1671,7 +1671,7 @@ end
 function ItemRack.CooldownUpdate()
 	local inv,bag,slot,start,duration,name,remain
 	for i in pairs(ItemRackUser.ItemsUsed) do
-		start,duration = GetItemCooldown(i)
+		start,duration = C_Container.GetItemCooldown(i)
 		if start and ItemRackUser.ItemsUsed[i]<3 then
 			ItemRackUser.ItemsUsed[i] = ItemRackUser.ItemsUsed[i] + 1 -- count for 3 seconds before seeing if this is a real cooldown
 		elseif start then

--- a/ItemRack/ItemRackEquip.lua
+++ b/ItemRack/ItemRackEquip.lua
@@ -145,8 +145,8 @@ function ItemRack.AnythingLocked()
 	end
 	if not isLocked then
 		for i=0,4 do
-			for j=1,GetContainerNumSlots(i) do
-				if select(3,GetContainerItemInfo(i,j)) then
+			for j=1,C_Container.GetContainerNumSlots(i) do
+				if select(3,C_Container.GetContainerItemInfo(i,j)) then
 					return 1
 				end
 			end
@@ -193,7 +193,7 @@ function ItemRack.IterateSwapList(setname)
 				inv,bag,slot = ItemRack.FindItem(swap[i],1)
 				if bag then
 					if i==16 and ItemRack.HasTitansGrip then
-						local subtype = select(7,GetItemInfo(GetContainerItemLink(bag,slot)))
+						local subtype = select(7,GetItemInfo(C_Container.GetContainerItemLink(bag,slot)))
 						if subtype and ItemRack.NoTitansGrip[subtype] then
 							treatAs2H = 1
 						end
@@ -276,7 +276,7 @@ function ItemRack.MoveItem(fromBag,fromSlot,toBag,toSlot)
 		return  -- oscarucb: ignore swap requests on slots containing "phantom" artifact items
 	elseif (not fromSlot and IsInventoryItemLocked(fromBag)) or (not toSlot and IsInventoryItemLocked(toBag)) then
 		abort = 4
-	elseif (fromSlot and select(3,GetContainerItemInfo(fromBag,fromSlot))) or (toSlot and select(3,GetContainerItemInfo(toBag,toSlot))) then
+	elseif (fromSlot and select(3,C_Container.GetContainerItemInfo(fromBag,fromSlot))) or (toSlot and select(3,C_Container.GetContainerItemInfo(toBag,toSlot))) then
 		abort = 4
 	end
 	if abort then
@@ -284,12 +284,12 @@ function ItemRack.MoveItem(fromBag,fromSlot,toBag,toSlot)
 		return
 	else
 		if fromSlot then
-			PickupContainerItem(fromBag,fromSlot)
+			C_Container.PickupContainerItem(fromBag,fromSlot)
 		else
 			PickupInventoryItem(fromBag)
 		end
 		if toSlot then
-			PickupContainerItem(toBag,toSlot)
+			C_Container.PickupContainerItem(toBag,toSlot)
 		else
 			PickupInventoryItem(toBag)
 		end


### PR DESCRIPTION
I think all the updates necessary were updating functions that had been moved into the C_Container namespace.

Reference: https://wowpedia.fandom.com/wiki/Patch_3.4.1/API_changes

I'm not an ItemRack power user so I may have missed some things, but I tested swapping sets manually and from triggers and I'm not getting any errors anymore.