### PR TITLE
Fixed item stuck on cursor when unequipping set

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -685,7 +685,11 @@ function ItemRack.GetID(bag,slot)
 	if ItemRack.AppendRuneID then
 		runeSuffix = ItemRack.AppendRuneID(bag,slot)
 	end
-	return ItemRack.GetIRString(itemLink)..runeSuffix
+	if runeSuffix ~= ""	then
+		return ItemRack.GetIRString(itemLink)..runeSuffix
+	else
+		return ItemRack.GetIRString(itemLink)
+	end
 end
 
 -- takes two ItemRack-style IDs (one or both of the parameters can be a baseID instead if needed) and returns true if those items share the same base itemID


### PR DESCRIPTION
Bug: When you have no shirt equipped, and you equip a set with a shirt and unequip the set, the shirt will get stuck on the cursor producing a "Swap stopped. Something is on the cursor" error.

Issue: ItemRackEquip.lua checks the following line to determine if an item should be unequipped or replaced.
`283:			if swap[k]==0 then -- if intended to be empty`
However, `swap[k] == "0"` not `0`, due to a change in commit 9c52da4 in `function ItemRack.GetID(bag,slot)` which appends runeSuffix or "" to all itemlinks.

Solution: ItemRack.GetID only appends runeSuffix if it is not just an empty string. Alternative solution would be to change line 283 to 
`283:			if swap[k]==0 or swap[k]=="0" then -- if intended to be empty`

Fixes: #254 
Fixes: #249 