### PR TITLE
Fix itemrack set matching in tooltips

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -955,6 +955,7 @@ function ItemRack.PopulateKnownItems()
 			end
 		end
 	end
+	ItemRack.KnownItems = known
 end
 
 --[[ Timers ]]

--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -451,11 +451,11 @@ function ItemRack.UpdateClassSpecificStuff()
 end
 
 function ItemRack.OnSetBagItem(tooltip, bag, slot)
-	ItemRack.ListSetsHavingItem(tooltip, ItemRack.GetID(bag, slot))
+	ItemRack.ListSetsHavingItem(tooltip, ItemRack.GetID(bag, slot), true)
 end
 
 function ItemRack.OnSetInventoryItem(tooltip, unit, inv_slot)
-	ItemRack.ListSetsHavingItem(tooltip, ItemRack.GetID(inv_slot))
+	ItemRack.ListSetsHavingItem(tooltip, ItemRack.GetID(inv_slot), true)
 end
 
 function ItemRack.OnSetHyperlink(tooltip, link)
@@ -465,16 +465,23 @@ end
 do
 	local data = {}
 
-	function ItemRack.ListSetsHavingItem(tooltip, id)
+	function ItemRack.ListSetsHavingItem(tooltip, id, exact)
 		if ItemRackSettings.ShowSetInTooltip ~= "ON" then
 			return
 		end
-		local same_ids = ItemRack.SameID
 		if not id or id == 0 then return end
+		local same_ids = ItemRack.SameID
 		for name, set in pairs(ItemRackUser.Sets) do
 			for _, item in pairs(set.equip) do
-				if same_ids(item, id) then
-					data[name] = true
+				if exact then
+					item = ItemRack.UpdateIRString(item)
+					if item==id then
+						data[name] = true
+					end
+				else
+					if same_ids(item, id) then
+						data[name] = true
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Use exact IDs for items in bags/inventory, and base IDs for links.

This fixes the problem where you might have two of the same item
but with different runes applied.  Before this fix, ItemRack
would show both items as belonging to both sets, which is only true
if the exact item from the set wasn't found at time of equip.

Now, we'll only show set information in tooltips for items in bags/
inventory if that exact item is part of a set.  Links from other
players will still show sets you have that include the same base item ID.

Also populate KnownItems.  It's being saved, but PopulateKnownItems()
is called regularly.