### PR TITLE
Check for valid bag slot before adding tooltip to it

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -451,10 +451,7 @@ function ItemRack.UpdateClassSpecificStuff()
 end
 
 function ItemRack.OnSetBagItem(tooltip, bag, slot)
-	local id = ItemRack.GetID(bag, slot)
-	if id ~= "0" then
-		ItemRack.ListSetsHavingItem(tooltip, id)
-	end
+	ItemRack.ListSetsHavingItem(tooltip, ItemRack.GetID(bag, slot))
 end
 
 function ItemRack.OnSetInventoryItem(tooltip, unit, inv_slot)
@@ -473,7 +470,7 @@ do
 			return
 		end
 		local same_ids = ItemRack.SameID
-		if not id or id == 0 then return end
+		if not id or id == 0 or id == "0" then return end
 		for name, set in pairs(ItemRackUser.Sets) do
 			for _, item in pairs(set.equip) do
 				if same_ids(item, id) then

--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -451,7 +451,10 @@ function ItemRack.UpdateClassSpecificStuff()
 end
 
 function ItemRack.OnSetBagItem(tooltip, bag, slot)
-	ItemRack.ListSetsHavingItem(tooltip, ItemRack.GetID(bag, slot))
+	local id = ItemRack.GetID(bag, slot)
+	if id ~= "0" then
+		ItemRack.ListSetsHavingItem(tooltip, id)
+	end
 end
 
 function ItemRack.OnSetInventoryItem(tooltip, unit, inv_slot)


### PR DESCRIPTION
This fixes issues with custom buttons with custom tooltips from other addons.

Example:
[BetterBags](https://github.com/Cidan/BetterBags) creates a dummy button for displaying empty bag slots.

Before:
![grafik](https://github.com/Rottenbeer/ItemRack/assets/16212271/a5bb50a5-66cd-4d31-84da-dc6df258e211)

After:
![grafik](https://github.com/Rottenbeer/ItemRack/assets/16212271/9b802fe5-6a1d-491b-9ec9-eac2790b11b3)
