### PR TITLE
fix for WoW SoD MouseFocus -> MouseFoci

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -1314,7 +1314,7 @@ function ItemRack.WriteMenuCooldowns()
 end
 
 function ItemRack.MenuMouseover()
-	local frame = GetMouseFocus()
+	local frame = GetMouseFoci()[1]
 	local frameName = nil
 	local frameVisible = nil
 	local IRmouseOverFrame = nil


### PR DESCRIPTION
A recent SoD version broke ItemRack by changing a function GetMouseFocus() to GetMouseFoci(), which returns an array instead of a single value.  

This patch implements a quick fix that I got on the Simonize rogue discord: https://discord.com/channels/808033004797952021/808070665177399316/1288822112173166676

I'm just pushing it forward.  :)