### PR TITLE
Fix problems related to ranged slot remowal in MOP

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -183,8 +183,7 @@ ItemRack.SlotInfo = {
 	[15] = { name="BackSlot", real="Cloak", INVTYPE_CLOAK=1 },
 	[16] = { name="MainHandSlot", real="Main hand", INVTYPE_WEAPONMAINHAND=1, INVTYPE_2HWEAPON=1, INVTYPE_WEAPON=1, other=17},
 	[17] = { name="SecondaryHandSlot", real="Off hand", INVTYPE_WEAPON=1, INVTYPE_WEAPONOFFHAND=1, INVTYPE_SHIELD=1, INVTYPE_HOLDABLE=1, other=16},
-	[18] = { name="RangedSlot", real="Ranged", INVTYPE_RANGED=1, INVTYPE_RANGEDRIGHT=1, INVTYPE_THROWN=1, INVTYPE_RELIC=1},
-	[19] = { name="TabardSlot", real="Tabard", INVTYPE_TABARD=1 },
+	[18] = { name="TabardSlot", real="Tabard", INVTYPE_TABARD=1 },
 }
 
 ItemRack.DockInfo = {  -- docking-dependent values
@@ -382,7 +381,7 @@ function ItemRack.OnUnitInventoryChanged(self,event,unit)
 			ItemRack.BuildMenu()
 		end
 		if ItemRackOptFrame and ItemRackOptFrame:IsVisible() then
-			for i=0,19 do
+			for i=0,18 do
 				if not ItemRackOpt.Inv[i].selected then
 					ItemRackOpt.Inv[i].id = ItemRack.GetID(i)
 				end
@@ -633,12 +632,12 @@ function ItemRack.UpdateCurrentSet()
 	if setname and setname ~= _G.CUSTOM then
 		local equipped = ItemRack.IsSetEquipped(setname)
 		if equipped then
-			texture = ItemRack.GetTextureBySlot(20)
+			texture = ItemRack.GetTextureBySlot(19)
 		else
 			setname = _G.CUSTOM
 		end
 	end
-	if ItemRackButton20 and ItemRackUser.Buttons[20] then
+	if ItemRackButton20 and ItemRackUser.Buttons[19] then
 		ItemRackButton20Icon:SetTexture(texture)
 		ItemRackButton20Name:SetText(setname)
 	end
@@ -649,7 +648,7 @@ end
 --[[ Item info gathering ]]
 
 function ItemRack.GetTextureBySlot(slot)
-	if slot==20 then
+	if slot==19 then
 		if ItemRackUser.CurrentSet and ItemRackUser.Sets[ItemRackUser.CurrentSet] then
 			return ItemRackUser.Sets[ItemRackUser.CurrentSet].icon
 		else
@@ -783,7 +782,7 @@ function ItemRack.FindItem(id,lock)
 		end
 	end
 	-- search worn equipment
-	for i=0,19 do
+	for i=0,18 do
 		if id==getid(i) and (not lock or not locklist[-2][i]) then
 			if lock then locklist[-2][i]=1 end
 			return i
@@ -799,7 +798,7 @@ function ItemRack.FindItem(id,lock)
 		end
 	end
 	-- search worn equipment for base id matches
-	for i=0,19 do
+	for i=0,18 do
 		if sameid(id,getid(i)) and (not lock or not locklist[-2][i]) then
 			if lock then locklist[-2][i]=1 end
 			return i
@@ -966,7 +965,7 @@ function ItemRack.PopulateKnownItems()
 	end
 	local id
 	local getid = ItemRack.GetID
-	for i=0,19 do
+	for i=0,18 do
 		id = getid(i) --grab ItemRack-style ID for every currently worn equipment piece
 		if id~=0 then
 			known[id] = i*-1 --we were able to generate a valid ID for this item, so store its location (slot)
@@ -1093,7 +1092,7 @@ function ItemRack.AddToMenu(itemID)
 end
 
 -- builds a popout menu for slots or set button
--- id = 0-19 for inventory slots, or 20 for set, or nil for last defined slot/set menu (ItemRack.menuOpen)
+-- id = 0-18 for inventory slots, or 19 for set, or nil for last defined slot/set menu (ItemRack.menuOpen)
 -- before calling ItemRack.BuildMenu, you should call ItemRack.DockWindows
 -- if menuInclude, then also include the worn item(s) in the menu
 function ItemRack.BuildMenu(id,menuInclude,masqueGroup)
@@ -1113,7 +1112,7 @@ function ItemRack.BuildMenu(id,menuInclude,masqueGroup)
 
 	local itemLink,itemID,itemName,equipSlot,itemTexture
 
-	if id<20 then
+	if id<19 then
 		if menuInclude then
 			itemID = ItemRack.GetID(id)
 			if itemID~=0 then
@@ -1259,7 +1258,7 @@ function ItemRack.BuildMenu(id,menuInclude,masqueGroup)
 		for i=1,#(ItemRack.Menu) do
 			border = _G["ItemRackMenu"..i.."Border"]
 			border:Hide()
-			if ItemRack.menuOpen==20 then
+			if ItemRack.menuOpen==19 then
 				_G["ItemRackMenu"..i.."Name"]:SetText(ItemRack.Menu[i])
 				local missing = ItemRack.MissingItems(ItemRack.Menu[i])
 				if missing==0 then
@@ -1290,7 +1289,7 @@ function ItemRack.UpdateMenuCooldowns()
 	local baseID
 	for i=1,#(ItemRack.Menu) do
 		baseID = tonumber(ItemRack.GetIRString(ItemRack.Menu[i],true)) --get baseID and convert it to number to be able to use it in numerical comparisons below
-		if baseID and baseID>0 and ItemRack.menuOpen<20 then
+		if baseID and baseID>0 and ItemRack.menuOpen<19 then
 			CooldownFrame_Set(_G["ItemRackMenu"..i.."Cooldown"],GetItemCooldown(baseID))
 		else
 			_G["ItemRackMenu"..i.."Cooldown"]:Hide()
@@ -1404,7 +1403,7 @@ function ItemRack.MenuOnClick(self,button)
 			ItemRackOpt.UpdateInv()
 			ItemRackMenuFrame:Hide()
 		end
-	elseif ItemRack.menuOpen<20 then
+	elseif ItemRack.menuOpen<19 then
 		if ItemRack.BankOpen then
 			if ItemRack.GetCountByID(item)==0 then
 				local bankBag,bankSlot = ItemRack.FindInBank(item)
@@ -1441,7 +1440,7 @@ function ItemRack.MenuOnClick(self,button)
 			ItemRack.EquipItemByID(item,ItemRack.menuOpen)
 			ItemRackMenuFrame:Hide()
 		end
-	elseif ItemRack.menuOpen==20 then
+	elseif ItemRack.menuOpen==19 then
 		if ItemRack.BankOpen then
 			if ItemRack.MissingItems(item)==1 then
 				ItemRack.GetBankedSet(item)
@@ -1526,7 +1525,7 @@ function ItemRack.newUseAction(slot,cursor,self)
 	if IsEquippedAction(slot) then
 		local actionType,actionId = GetActionInfo(slot)
 		if actionType=="item" then
-			for i=0,19 do
+			for i=0,18 do
 				if tonumber(ItemRack.GetIRString(GetInventoryItemLink("player",i),true,true))==actionId then --compare baseID of given item (converted to number) to actionId
 					ItemRack.ReflectItemUse(i)
 					break
@@ -1537,7 +1536,7 @@ function ItemRack.newUseAction(slot,cursor,self)
 end
 
 function ItemRack.newUseItemByName(name)
-	for i=0,19 do
+	for i=0,18 do
 		if name==GetItemInfo(GetInventoryItemLink("player",i) or 0) then
 			ItemRack.ReflectItemUse(i)
 			break
@@ -1576,12 +1575,12 @@ function ItemRack.UpdateCombatQueue()
 			queue:SetTexture("Interface\\AddOns\\ItemRack\\ItemRackGear")
 			queue:SetAlpha(ItemRackUser.EnableQueues=="ON" and 1 or .5)
 			queue:Show()
-		elseif i~=20 then
+		elseif i~=19 then
 			queue:Hide()
 		end
 	end
 
-	for i=1,19 do
+	for i=1,18 do
 		queue = _G["Character"..ItemRack.SlotInfo[i].name.."Queue"]
 		if ItemRack.CombatQueue[i] then
 			queue:SetTexture(select(2,ItemRack.GetInfoByID(ItemRack.CombatQueue[i])))
@@ -1598,7 +1597,7 @@ end
 -- request a tooltip of an inventory slot
 function ItemRack.InventoryTooltip(self)
 	local id = self:GetID()
-	if id==20 then
+	if id==19 then
 		ItemRack.SetTooltip(self,ItemRackUser.CurrentSet)
 	else
 		ItemRack.TooltipOwner = self
@@ -1612,7 +1611,7 @@ end
 -- request a tooltip of a menu item (called when hovering over a button in the popout menu of SET NAMES that comes up when clicking the minimap button or bar addon plugin, this is NOT the "Sets" dropdown INSIDE ItemRack's GUI)
 function ItemRack.MenuTooltip(self)
 	local id = self:GetID()
-	if ItemRack.menuOpen==20 then
+	if ItemRack.menuOpen==19 then
 		ItemRack.SetTooltip(self,ItemRack.Menu[id])
 	else
 		ItemRack.TooltipOwner = self
@@ -1754,7 +1753,7 @@ function ItemRack.SetTooltip(self,setname)
 		ItemRack.AnchorTooltip(self)
 		GameTooltip:AddLine(setname)
 		if ItemRackSettings.TinyTooltips~="ON" then
-			for i=0,19 do
+			for i=0,18 do
 				if set[i] then
 					itemName = ItemRack.GetInfoByID(set[i])
 					if itemName then
@@ -1857,13 +1856,13 @@ end
 function ItemRack.DockMenuToCharacterSheet(self)
 	local name = self:GetName()
 	local slot
-	for i=0,19 do
+	for i=0,18 do
 		if name=="Character"..ItemRack.SlotInfo[i].name then
 			slot = i
 		end
 	end
 	if slot then
-		if slot==0 or (slot>=16 and slot<=18) then
+		if slot==0 or (slot>=16 and slot<=17) then
 			ItemRack.DockWindows("TOPLEFT",self,"BOTTOMLEFT","VERTICAL")
 		else
 			if slot==14 and ItemRackSettings.TrinketMenuMode=="ON" then
@@ -1878,7 +1877,7 @@ end
 --[[ Minimap button ]]
 
 function ItemRack.InitBroker()
-	local texture = ItemRack.GetTextureBySlot(20)
+	local texture = ItemRack.GetTextureBySlot(19)
 	texture = [[Interface\AddOns\ItemRack\ItemRackIcon]]
 	ItemRack.Broker = LDB:NewDataObject("ItemRack", {
 		type = "launcher",
@@ -1917,7 +1916,7 @@ function ItemRack.MinimapOnClick(self,button)
 			else
 				ItemRack.DockWindows("BOTTOMRIGHT",self,"TOPRIGHT","VERTICAL")
 			end
-			ItemRack.BuildMenu(20, nil, 4)
+			ItemRack.BuildMenu(19, nil, 4)
 		end
 	else
 		ItemRack.ToggleOptions(self)
@@ -1979,7 +1978,7 @@ end
 
 function ItemRack.ReflectAlpha()
 	if ItemRackButton0 then
-		for i=0,20 do
+		for i=0,19 do
 			_G["ItemRackButton"..i]:SetAlpha(ItemRackUser.Alpha)
 		end
 	end
@@ -2011,7 +2010,7 @@ end
 
 function ItemRack.ReflectCooldownFont()
 	local item
-	for i=0,20 do
+	for i=0,19 do
 		ItemRack.SetFont("ItemRackButton"..i)
 	end
 	local i=1

--- a/ItemRack/ItemRackButtons.lua
+++ b/ItemRack/ItemRackButtons.lua
@@ -34,7 +34,7 @@ function ItemRack.InitButtons()
 
 
 	local button
-	for i=0,20 do
+	for i=0,19 do
 		button = _G["ItemRackButton"..i]
 		if i<20 then
 			button:SetAttribute("type","item")
@@ -81,7 +81,7 @@ end
 
 function ItemRack.UpdateDisableAltClick()
 	if not InCombatLockdown() then
-		for i=0,19 do
+		for i=0,18 do
 			_G["ItemRackButton"..i]:SetAttribute("alt-slot*",ItemRackSettings.DisableAltClick=="OFF" and ATTRIBUTE_NOOP or nil)
 		end
 	end
@@ -106,7 +106,7 @@ end
 
 function ItemRack.newCharacterModelFrame_OnMouseUp(self, button)
 	if IsAltKeyDown() then
-		ItemRack.ToggleButton(20)
+		ItemRack.ToggleButton(19)
 	end
 	ItemRack.oldCharacterModelFrame_OnMouseUp(self, button)
 end
@@ -127,7 +127,7 @@ function ItemRack.AddButton(id)
 	_G["ItemRackButton"..id.."Icon"]:SetTexture(ItemRack.GetTextureBySlot(id))
 	button:Show()
 	ItemRack.UpdateButtonCooldowns()
-	if id==20 then
+	if id==19 then
 		ItemRack.UpdateCurrentSet()
 		if ItemRack.ReflectEventsRunning then
 			ItemRack.ReflectEventsRunning()
@@ -502,7 +502,7 @@ function ItemRack.ButtonPostClick(self,button)
 			ItemRack.BuildMenu(id, nil, 2)
 		end
 	elseif IsShiftKeyDown() then
-		if id<20 then
+		if id<19 then
 			if ChatFrame1EditBox:IsVisible() then
 				ChatFrame1EditBox:Insert(GetInventoryItemLink("player",id))
 			end
@@ -510,7 +510,7 @@ function ItemRack.ButtonPostClick(self,button)
 			ItemRack.UnequipSet(ItemRackUser.CurrentSet)
 		end
 	elseif IsAltKeyDown() then
-		if id<20 and ItemRackSettings.DisableAltClick=="OFF" then
+		if id<19 and ItemRackSettings.DisableAltClick=="OFF" then
 			if not ItemRack.GetQueues()[id] then
 				LoadAddOn("ItemRackOptions")
 				ItemRackOptFrame:Show()
@@ -522,12 +522,12 @@ function ItemRack.ButtonPostClick(self,button)
 				ItemRackOptQueueEnable:SetChecked(ItemRack.GetQueuesEnabled()[id])
 			end
 			ItemRack.UpdateCombatQueue()
-		elseif id==20 then
+		elseif id==19 then
 			ItemRack.ToggleEvents(self)
 		end
-	elseif id<20 then
+	elseif id<19 then
 		ItemRack.ReflectItemUse(id)
-	elseif id==20 then
+	elseif id==19 then
 		if button=="LeftButton" and ItemRackUser.CurrentSet then
 			if ItemRackSettings.EquipToggle=="ON" then
 				ItemRack.ToggleSet(ItemRackUser.CurrentSet)
@@ -607,7 +607,7 @@ function ItemRack.ButtonMenuOnClick(self)
 		else
 			LoadAddOn("ItemRackOptions")
 			ItemRackOptFrame:Show()
-			if ItemRack.menuOpen<20 then
+			if ItemRack.menuOpen<19 then
 				ItemRackOpt.TabOnClick(self,4)
 				ItemRackOpt.SetupQueue(ItemRack.menuOpen)
 			else
@@ -624,7 +624,7 @@ function ItemRack.ReflectMainScale(changing)
 	end
 	local scale = ItemRackUser.MainScale or 1
 	local button
-	for i=0,20 do
+	for i=0,19 do
 		button = ItemRackUser.Buttons[i]
 		if not changing or not button or not button.Left then
 			_G["ItemRackButton"..i]:SetScale(scale)
@@ -642,7 +642,7 @@ function ItemRack.ReflectMainScale(changing)
 end
 
 function ItemRack.ReflectMenuOnRight()
-	for i=0,20 do
+	for i=0,19 do
 		_G["ItemRackButton"..i]:SetAttribute("slot2",ItemRackSettings.MenuOnRight=="ON" and ATTRIBUTE_NOOP or nil)
 	end
 end

--- a/ItemRack/ItemRackEquip.lua
+++ b/ItemRack/ItemRackEquip.lua
@@ -272,7 +272,7 @@ function ItemRack.IterateSwapList(setname)
 
 	local treatAs2H = nil
 	local skip, inv, bag, slot
-	for k=0,19+ItemRack.eqBackOfTheBusOffset do
+	for k=0,18+ItemRack.eqBackOfTheBusOffset do
 		local i = k
 		if k >= ItemRack.eqBackOfTheBusOffset then
 			i = k-ItemRack.eqBackOfTheBusOffset

--- a/ItemRack/ItemRackEvents.lua
+++ b/ItemRack/ItemRackEvents.lua
@@ -456,7 +456,7 @@ local prevIcon, prevText
 function ItemRack.ReflectEventsRunning()
 	if ItemRackUser.EnableEvents=="ON" and next(ItemRackUser.Events.Enabled) then
 		-- if events enabled and an event is enabled, show gear icons on set and minimap button
-		if ItemRackUser.Buttons[20] then
+		if ItemRackUser.Buttons[19] then
 			ItemRackButton20Queue:Show()
 		end
 		prevIcon = ItemRack.Broker.icon
@@ -464,7 +464,7 @@ function ItemRack.ReflectEventsRunning()
 		ItemRack.Broker.icon = [[Interface\AddOns\ItemRack\ItemRackGear]]
 		ItemRack.Broker.text = "..."
 	else
-		if ItemRackUser.Buttons[20] then
+		if ItemRackUser.Buttons[19] then
 			ItemRackButton20Queue:Hide()
 		end
 		if prevIcon then

--- a/ItemRackOptions/ItemRackOptions.lua
+++ b/ItemRackOptions/ItemRackOptions.lua
@@ -8,7 +8,7 @@ ItemRackOpt = {
 	selectedIcon = 0,
 	prevFrame = nil, -- previous subframe a frame should return to (ItemRackOptSubFrame1-x)
 	numSubFrames = 8, -- number of subframes
-	slotOrder = {1,2,3,15,5,4,19,9,16,17,18,0,14,13,12,11,8,7,6,10,6,7,8,11,12,13,14,0,18,17,16,9,19,4,5,15,3,2},
+	slotOrder = {1,2,3,15,5,4,9,16,17,18,0,14,13,12,11,8,7,6,10,6,7,8,11,12,13,14,0,18,17,16,9,4,5,15,3,2},
 	currentMarquee = 1,
 }
 
@@ -41,7 +41,7 @@ function ItemRackOpt.InvOnEnter(self)
 		return
 	end
 	local menuDock,mainDock,menuOrient = "TOPRIGHT","TOPLEFT","HORIZONTAL"
-	if id==0 or (id>=16 and id<=18) then
+	if id==0 or (id>=16 and id<=17) then
 		menuDock,mainDock,menuOrient = "TOPLEFT","BOTTOMLEFT","VERTICAL"
 	elseif id>=6 and id<=14 and id~=9 then
 		menuDock,mainDock = "TOPLEFT","TOPRIGHT"
@@ -70,7 +70,7 @@ function ItemRackOpt.OnLoad(self)
 		insets = {left = 4, right = 4, top = 4, bottom = 4},
 	})
 	ItemRackOptInv0:SetScale(.8)
-	for i=0,19 do
+	for i=0,18 do
 		ItemRackOpt.Inv[i] = {}
 		ItemRackOpt.HoldInv[i] = {}
 	end
@@ -179,18 +179,18 @@ function ItemRackOpt.InitializeSliders()
 end
 
 function ItemRackOpt.OnShow(setname)
-	for i=0,19 do
+	for i=0,18 do
 		ItemRackOpt.Inv[i].id = ItemRack.GetID(i)
 	end
 	if ItemRackUser.CurrentSet and ItemRackUser.Sets[ItemRackUser.CurrentSet] then
 		ItemRackOptSetsName:SetText(ItemRackUser.CurrentSet)
 		ItemRackOpt.selectedIcon = ItemRackUser.Sets[ItemRackUser.CurrentSet].icon
-		for i=0,19 do
+		for i=0,18 do
 			ItemRackOpt.Inv[i].selected = ItemRackUser.Sets[ItemRackUser.CurrentSet].equip[i] and 1 or nil
 		end
 	else
 		ItemRackOptSetsName:SetText("")
-		ItemRackOpt.selectedIcon = ItemRackOpt.Icons[math.random(#(ItemRackOpt.Icons)-20)+20]
+		ItemRackOpt.selectedIcon = ItemRackOpt.Icons[math.random(#(ItemRackOpt.Icons)-19)+19]
 	end
 	ItemRackOpt.UpdateInv()
 	ItemRackOptSubFrame5:Hide()
@@ -201,7 +201,7 @@ function ItemRackOpt.ChangeEditingSet()
 	local setname = ItemRackUser.CurrentSet
 	if setname and ItemRackUser.Sets[setname] then
 		local set = ItemRackUser.Sets[setname].equip
-		for i=0,19 do
+		for i=0,18 do
 			if set[i] then
 				ItemRackOpt.Inv[i].id = set[i]
 				ItemRackOpt.Inv[i].selected = 1
@@ -220,7 +220,7 @@ end
 function ItemRackOpt.UpdateInv()
 	if ItemRack.IsTimerActive("SlotMarquee") then return end
 	local icon,texture,border,item
-	for i=0,19 do
+	for i=0,18 do
 		icon = _G["ItemRackOptInv"..i.."Icon"]
 		border = _G["ItemRackOptInv"..i.."Border"]
 		border:Hide()
@@ -278,7 +278,7 @@ function ItemRackOpt.ButtonOnClick(self)
 
 	if button=="ItemRackOptToggleInvAll" then
 		local state = not ItemRackOpt.Inv[1].selected
-		for i=0,19 do
+		for i=0,18 do
 			ItemRackOpt.Inv[i].selected = state
 		end
 		ItemRackOpt.UpdateInv()
@@ -343,7 +343,7 @@ end
 
 function ItemRackOpt.PopulateInvIcons()
 	local texture
-	for i=0,19 do
+	for i=0,18 do
 		if ItemRackOpt.Inv[i].id and ItemRackOpt.Inv[i].id~=0 then
 			_,texture = ItemRack.GetInfoByID(ItemRackOpt.Inv[i].id)
 		else
@@ -356,7 +356,7 @@ end
 
 function ItemRackOpt.PopulateInitialIcons()
 	ItemRackOpt.Icons = {}
-	for i=0,19 do
+	for i=0,18 do
 		table.insert(ItemRackOpt.Icons,"Interface\\Icons\\INV_Misc_QuestionMark")
 	end
 	ItemRackOpt.PopulateInvIcons()
@@ -427,7 +427,7 @@ function ItemRackOpt.SaveSet()
 	set.oldset = nil
 	set.old = {}
 	set.equip = {}
-	for i=0,19 do
+	for i=0,18 do
 		if ItemRackOpt.Inv[i].selected then
 			set.equip[i] = ItemRackOpt.Inv[i].id
 		end
@@ -454,7 +454,7 @@ function ItemRackOpt.ValidateSetButtons()
 
 	local setname = ItemRackOptSetsName:GetText()
 	if string.len(setname)>0 and not ItemRack.SetnameBlacklist[setname] then
-		for i=0,19 do
+		for i=0,18 do
 			if ItemRackOpt.Inv[i].selected then
 				ItemRackOptSetsSaveButton:Enable()
 				break
@@ -512,7 +512,7 @@ function ItemRackOpt.LoadSet()
 	local setname = ItemRackOptSetsName:GetText()
 	if ItemRackUser.Sets[setname] then
 		local set = ItemRackUser.Sets[setname].equip
-		for i=0,19 do
+		for i=0,18 do
 			ItemRackOpt.Inv[i].selected = nil
 			if set[i] then
 				ItemRackOpt.Inv[i].id = set[i]
@@ -560,14 +560,14 @@ function ItemRackOpt.MakeEscable(frame,add)
 end
 
 function ItemRackOpt.SaveInv()
-	for i=0,19 do
+	for i=0,18 do
 		ItemRackOpt.HoldInv[i].id = ItemRackOpt.Inv[i].id
 		ItemRackOpt.HoldInv[i].selected = ItemRackOpt.Inv[i].selected
 	end
 end
 
 function ItemRackOpt.RestoreInv()
-	for i=0,19 do
+	for i=0,18 do
 		ItemRackOpt.Inv[i].id = ItemRackOpt.HoldInv[i].id
 		ItemRackOpt.Inv[i].selected = ItemRackOpt.HoldInv[i].selected
 	end
@@ -607,7 +607,7 @@ end
 function ItemRackOpt.SetListOnEnter(self)
 	_G[self:GetName().."Highlight"]:Show()
 	local set = ItemRackUser.Sets[ItemRackOpt.SetList[self:GetID()+FauxScrollFrame_GetOffset(ItemRackOptSetListScrollFrame)]].equip
-	for i=0,19 do
+	for i=0,18 do
 		if set[i] then
 			ItemRackOpt.Inv[i].id = set[i]
 			ItemRackOpt.Inv[i].selected = 1
@@ -662,7 +662,7 @@ end
 -- when a set is chosen in the set list
 function ItemRackOpt.SelectSetList(self)
 	local setname = ItemRackOpt.SetList[self:GetID()+FauxScrollFrame_GetOffset(ItemRackOptSetListScrollFrame)]
-	for i=0,19 do
+	for i=0,18 do
 		ItemRackOpt.HoldInv[i].id = ItemRackOpt.Inv[i].id
 		ItemRackOpt.HoldInv[i].selected = ItemRackOpt.Inv[i].selected
 	end
@@ -1089,7 +1089,7 @@ end
 
 function ItemRackOpt.StartMarquee()
 	ItemRackOpt.SaveInv()
-	for i=0,19 do
+	for i=0,18 do
 		ItemRackOpt.Inv[i].selected = nil
 	end
 	ItemRackOptToggleInvAll:Hide()
@@ -1130,7 +1130,7 @@ function ItemRackOpt.SlotQueueFrameOnShow()
 	ItemRackOpt.MakeEscable("ItemRackOptSubFrame7","add")
 	ItemRackOpt.MakeEscable("ItemRackOptFrame","remove")
 	ItemRackOpt.HideCurrentSubFrame(7)
-	for i=0,19 do
+	for i=0,18 do
 		_G["ItemRackOptInv"..i]:Hide()
 	end
 	ItemRackOptToggleInvAll:Hide()
@@ -1140,7 +1140,7 @@ function ItemRackOpt.SlotQueueFrameOnHide()
 	ItemRackOpt.MakeEscable("ItemRackOptSubFrame7","remove")
 	ItemRackOpt.MakeEscable("ItemRackOptFrame","add")
 	ItemRackOpt.ShowPrevSubFrame()
-	for i=0,19 do
+	for i=0,18 do
 		_G["ItemRackOptInv"..i]:Show()
 	end
 	ItemRackOptToggleInvAll:Show()


### PR DESCRIPTION
In MOP classic there is no ranged slot, this causes a lot of issues for itemrack (mainly indexing errors). I removed the use of the ranged slot - this solves the immediate problems as far as I can see.