### PR TITLE
Adjusted the tooltip line index for soulbound

### DIFF
--- a/ItemRack/ItemRack.lua
+++ b/ItemRack/ItemRack.lua
@@ -938,7 +938,7 @@ end
 
 function ItemRack.IsSoulbound(bag,slot)
 	ItemRackTooltip:SetBagItem(bag,slot)
-	for i=2,5 do
+	for i=2,6 do
 		local text = _G["ItemRackTooltipTextLeft"..i]:GetText()
 		if text==ITEM_SOULBOUND or text==ITEM_BIND_QUEST or text==ITEM_CONJURED then
 			return 1


### PR DESCRIPTION
With the tooltip changes placing the item level at the top, the index for the soulbound identifier may now fall outside the previously expected range